### PR TITLE
Workaround to pass `/bigobj` to users of the library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,9 @@
 # Use `binary` to make sure certain files are never auto-detected as text.
 #
 #*.png binary
+
+# See: https://build2.org/article/symlinks.xhtml#windows
+libigl-core/igl symlink=dir
+libigl-core-tests/data symlink=dir
+libigl-core-tests/test_igl_core/igl symlink=dir
+

--- a/libigl-core-tests/test_igl_core/buildfile
+++ b/libigl-core-tests/test_igl_core/buildfile
@@ -9,6 +9,3 @@ exe{test_igl_core}: {hxx cxx}{*} igl/{hxx cxx}{*} $libs testscript
 cxx.poptions += "-I$src_base"
 cxx.poptions += -DLIBIGL_DATA_DIR="\"$regex.replace($src_root, '\\', '\\\\')/data\""
 cxx.poptions += -DCATCH_CONFIG_ENABLE_BENCHMARKING
-
-if ($cxx.target.system == 'win32-msvc')
-  cxx.coptions += /bigobj

--- a/libigl-core/buildfile
+++ b/libigl-core/buildfile
@@ -12,8 +12,7 @@ else
 {
   lib{igl-core}:
   {
-    cxx.export.poptions += -DNOMINMAX
-    cxx.export.coptions = /bigobj
+    cxx.export.poptions += -DNOMINMAX /bigobj
   }
 }
 


### PR DESCRIPTION
Discussion https://github.com/build2/build2/issues/316

Based on https://github.com/lyrahgames/build2-libigl/pull/1 so ignore the symlink changes here.